### PR TITLE
add fix for bundle install failure due to image not being seen - usua…

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ brew unlink imagemagick
 brew install imagemagick@6 && brew link imagemagick@6 --force
 ```
 
+Note: if you have error `bundle install` on jungle with bundler image issues, this are the command to fix by installing the exact bundler
+```
+gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
+```
+
 ## BONUS STUFF TO INSTALL
 
 ###Installing Postico


### PR DESCRIPTION
add fix for bundle install failure due to image not being seen - eg because of osx upgrade to Catalina